### PR TITLE
Font-weight of Prices Changed

### DIFF
--- a/sendInvoice.html
+++ b/sendInvoice.html
@@ -392,17 +392,17 @@
                               </thead>
                               <tbody>
                                 <tr scope="row">
-                                  <td>Mobile App UI</td>
-                                  <td>1</td>
-                                  <td>US$8,800.00</td>
-                                  <td>US$8,800.00</td>
+                                  <td style="font-weight:normal">Mobile App UI</td>
+                                  <td style="font-weight:normal">1</td>
+                                  <td style="font-weight:normal">US$8,800.00</td>
+                                  <td style="font-weight:normal">US$8,800.00</td>
                                 </tr>
                                 <tr scope="row">
                                     <td></td>
                                     <td></td>
                                     <td style="font-weight:bold">Subtotal<br>Total<br>Amount Due
                                     </td>
-                                    <td>US$8,800.00<br>US$8,800.00<br>US$8,800.00</td>
+                                    <td style="font-weight:normal">US$8,800.00<br>US$8,800.00<br>US$8,800.00</td>
                                 </tr>
                               </tbody>
                             </table>


### PR DESCRIPTION
From the design on Figma, the prices and second row of the table are not bold. Because we've set a general style to bold all text in our internal css, these prices are also bold. 

I then give each part an inline css to change their font-weight to normal, which tally with what is on Figma.

![Screenshot_2019-10-11-13-08-30](https://user-images.githubusercontent.com/50958501/66650413-75c1e880-ec28-11e9-8257-2abbb8849e03.png)

![Screenshot_2019-10-11-13-08-16](https://user-images.githubusercontent.com/50958501/66650459-95591100-ec28-11e9-8d78-04ffda0cc699.png)

The first screenshot is what we have earlier, the second screenshot is showing the effect of the inline css I add. 
